### PR TITLE
fix: se corrigieron las funciones one() y main()

### DIFF
--- a/src/BinaryDb.php
+++ b/src/BinaryDb.php
@@ -111,13 +111,14 @@ class BinaryDb
         $query = ' FOR d IN ' . self::$nodesCollection . ' ' . $filter . ' SORT d.dateUpdate RETURN d ';
         return self::query($query);
     }
-    public static function one(string $id)
+    public static function one(string $key,string $layer = 'node')
     {
-        return self::query("RETURN DOCUMENT('$id')")[0];
+        $collection = self::layer($layer);
+        return self::query("RETURN DOCUMENT('".$collection.'/'.$key."')")[0];
     }
     public static function main()
     {
-        $out = self::one(self::$nodesCollection . '/' . self::$mainNode);
+        $out = self::one(self::$mainNode);
         return $out;
     }
     public static function parents(string $key)

--- a/src/BinaryDb.php
+++ b/src/BinaryDb.php
@@ -41,7 +41,7 @@ class BinaryDb
         self::$options = $options;
 
         $config = Config::load($options);
-        
+
         $this->connectionOptions = $config['config'];
         self::$mainNode = $config['mainNode'];
         self::$nodesCollection = $config['nodesCollection'];
@@ -111,10 +111,10 @@ class BinaryDb
         $query = ' FOR d IN ' . self::$nodesCollection . ' ' . $filter . ' SORT d.dateUpdate RETURN d ';
         return self::query($query);
     }
-    public static function one(string $key,string $layer = 'node')
+    public static function one(string $key, string $layer = 'node')
     {
         $collection = self::layer($layer);
-        return self::query("RETURN DOCUMENT('".$collection.'/'.$key."')")[0];
+        return self::query("RETURN DOCUMENT('" . $collection . '/' . $key . "')")[0];
     }
     public static function main()
     {

--- a/tests/BinaryDbTest.php
+++ b/tests/BinaryDbTest.php
@@ -9,8 +9,7 @@ class BinaryDbTest extends TestCase
 {
     public function testStart()
     {
-        $connection = BinaryDb::start();
-
+        $connection = BinaryDb::start(['envDir' => 'src']);
         $this->assertContainsOnlyInstancesOf(BinaryDb::class, [$connection]);
     }
     public function testMain()
@@ -18,5 +17,12 @@ class BinaryDbTest extends TestCase
         $connection = BinaryDb::start(['envDir' => 'src']);
         $out = $connection::main();
         $this->assertArrayHasKey('_key', $out);
+    }
+    public function testOne()
+    {
+        $connection = BinaryDb::start(['envDir' => 'src']);
+        $main = $connection::one($connection::$mainNode);
+        //print_r($main);
+        $this->assertArrayHasKey('_id', $main);
     }
 }


### PR DESCRIPTION
se corrigio la funcion one() para que funcione por _key en vez de _id con la opcion de indicar si es la capa de aristas o nodos. Se adaptó la función de main() a este nuevo formato