### PR TITLE
fix: se cambio la respuesta  de children()

### DIFF
--- a/src/BinaryDb.php
+++ b/src/BinaryDb.php
@@ -158,7 +158,7 @@ class BinaryDb
             . self::$nodesCollection . '/' . $key . "' "
             . self::$edgesCollection
             . $filter
-            . ' RETURN {_key:node._key,id:node._id,_tag:node._tag,name:node.name}  ';
+            . ' RETURN {_key:node._key,id:node._id,_tag:edge._tag,name:node.name}  ';
         return self::query($query);
     }
     public static function remove($key, $layer = 'node')


### PR DESCRIPTION
En la respuesta anterior se daba la propiedad _tag del nodo, pero en el caso de un children debería entregarse la propiedad _tag de la arista.